### PR TITLE
Add additional disk space for aws default worker nodes

### DIFF
--- a/python/cloudtik/providers/aws/defaults.yaml
+++ b/python/cloudtik/providers/aws/defaults.yaml
@@ -69,6 +69,10 @@ available_node_types:
                 #   SpotOptions:
                 #       MaxPrice: MAX_HOURLY_PRICE
             # Additional options in the boto docs.
+            BlockDeviceMappings:
+                - DeviceName: /dev/sda1
+                  Ebs:
+                      VolumeSize: 100
 
 # Specify the node type of the head node (as configured above).
 head_node_type: head.default


### PR DESCRIPTION
1. The default EC2 worker node's disk space is 8G, it's too small to run TPC-DS datagen. Once the disk is full, the node will be teminated by AWS.
2. Can not find jq in the default image, so we need to check it before we call it when configure spark and hadoop.



 