### PR TITLE
Refine the output for TPC-DS performance data

### DIFF
--- a/tools/spark/benchmark/scripts/tpcds-power-test.scala
+++ b/tools/spark/benchmark/scripts/tpcds-power-test.scala
@@ -97,13 +97,10 @@ val experiment = tpcds.runExperiment(
 println(experiment.toString)
 experiment.waitForFinish(timeout*60*60)
 
-val res=experiment.getCurrentResults // or: spark.read.json(resultLocation).filter("timestamp = 1429132621024")
-  .withColumn("Name", substring(col("name"), 2, 100))
-  .withColumn("Runtime", (col("parsingTime") + col("analysisTime") + col("optimizationTime") + col("planningTime") + col("executionTime")) / 1000.0)
-  .select('Name, 'Runtime)
-res.show(104)
-
-val sumRuntime: Double = res.agg(sum("Runtime").cast("double")).first.getDouble(0)
+experiment.getCurrentResults.createOrReplaceTempView("result")
+sql("select substring(name,1,100) as Name, bround((parsingTime+analysisTime+optimizationTime+planningTime+executionTime)/1000.0,2) as Runtime_sec from result").show()
+val runtimeDF = sql("select bround((parsingTime+analysisTime+optimizationTime+planningTime+executionTime)/1000.0,2) as Runtime_sec from result")
+val sumRuntime = runtimeDF.map(_(0).asInstanceOf[Double]).reduce(_+_).formatted("%.2f")
 println(s"Total time: ${sumRuntime}s")
 
 sys.exit(0)

--- a/tools/spark/benchmark/scripts/tpcds-power-test.scala
+++ b/tools/spark/benchmark/scripts/tpcds-power-test.scala
@@ -97,10 +97,13 @@ val experiment = tpcds.runExperiment(
 println(experiment.toString)
 experiment.waitForFinish(timeout*60*60)
 
-experiment.getCurrentResults.createOrReplaceTempView("result")
-sql("select substring(name,1,100) as Name, bround((parsingTime+analysisTime+optimizationTime+planningTime+executionTime)/1000.0,2) as Runtime_sec from result").show()
-val runtimeDF = sql("select bround((parsingTime+analysisTime+optimizationTime+planningTime+executionTime)/1000.0,2) as Runtime_sec from result")
-val sumRuntime = runtimeDF.map(_(0).asInstanceOf[Double]).reduce(_+_).formatted("%.2f")
+val res=experiment.getCurrentResults // or: spark.read.json(resultLocation).filter("timestamp = 1429132621024")
+  .withColumn("Name", substring(col("name"), 1, 100))
+  .withColumn("Runtime", round(((col("parsingTime") + col("analysisTime") + col("optimizationTime") + col("planningTime") + col("executionTime")) / 1000.0), 2))
+  .select('Name, 'Runtime)
+res.show(104)
+
+val sumRuntime: Double = res.agg(sum("Runtime").cast("double")).first.getDouble(0)
 println(s"Total time: ${sumRuntime}s")
 
 sys.exit(0)


### PR DESCRIPTION
Previously
```
+------+------------------+                                                     
|  Name|           Runtime|
+------+------------------+
|1-v2.4|16.839554928000002|
|2-v2.4|      62.153238207|
+------+------------------+

Total time: 78.992793135s
```
This patch applies further refinement
```
+-------+-----------+                                                           
|   Name|Runtime_sec|
+-------+-----------+
|q1-v2.4|      16.43|
|q2-v2.4|      56.01|
+-------+-----------+

Total time: 72.44s
```