### PR TITLE
Ensure that COPY is used instead of ADD in Dockerfiles

### DIFF
--- a/docker/cloudtik-dev/Dockerfile
+++ b/docker/cloudtik-dev/Dockerfile
@@ -5,16 +5,13 @@ FROM cloudtik/cloudtik-deps:nightly
 
 COPY cloudtik.tar /tmp/cloudtik.tar
 
-WORKDIR /cloudtik
-RUN tar -xf /tmp/cloudtik.tar
-COPY git-rev ./git-rev
-
 # Install dependencies needed to build
 RUN sudo apt-get update && sudo apt-get install -y curl unzip cmake gcc g++ && sudo apt-get clean
-RUN sudo chown -R cloudtik:users /cloudtik && cd /cloudtik && git init
 
 WORKDIR /cloudtik/
-RUN bash build.sh
+COPY git-rev ./git-rev
+RUN tar -xf /tmp/cloudtik.tar && sudo chown -R cloudtik:users /cloudtik && git init \
+    && bash build.sh
 WORKDIR /cloudtik/python/
 RUN export PATH="$HOME/anaconda3/envs/$CLOUDTIK_ENV/bin:$PATH" \
     && pip install -e .

--- a/docker/cloudtik-dev/Dockerfile
+++ b/docker/cloudtik-dev/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM cloudtik/cloudtik-deps:nightly
 ADD cloudtik.tar /cloudtik
-ADD git-rev /cloudtik/git-rev
+COPY git-rev /cloudtik/git-rev
 
 # Install dependencies needed to build
 RUN sudo apt-get update && sudo apt-get install -y curl unzip cmake gcc g++ && sudo apt-get clean

--- a/docker/cloudtik-dev/Dockerfile
+++ b/docker/cloudtik-dev/Dockerfile
@@ -2,8 +2,12 @@
 # for developers that need the source code to actively modify.
 
 FROM cloudtik/cloudtik-deps:nightly
-ADD cloudtik.tar /cloudtik
-COPY git-rev /cloudtik/git-rev
+
+COPY cloudtik.tar /tmp/cloudtik.tar
+
+WORKDIR /cloudtik
+RUN tar -xf /tmp/cloudtik.tar
+COPY git-rev ./git-rev
 
 # Install dependencies needed to build
 RUN sudo apt-get update && sudo apt-get install -y curl unzip cmake gcc g++ && sudo apt-get clean


### PR DESCRIPTION
For items (files, directories) that do not require ADD’s tar auto-extraction capability, we should always use COPY.