### PR TITLE
Fix cloudtik submitting jobs with host mode on quoting scripts file

### DIFF
--- a/python/cloudtik/core/_private/cluster/cluster_operator.py
+++ b/python/cloudtik/core/_private/cluster/cluster_operator.py
@@ -3095,9 +3095,9 @@ def submit_and_exec(config: Dict[str, Any],
             target=target,
             down=False)
     if target_name.endswith(".py"):
-        command_parts += ["python", quote(target)]
+        command_parts += ["python", target]
     elif target_name.endswith(".sh"):
-        command_parts += ["bash", quote(target)]
+        command_parts += ["bash", target]
     else:
 
         command_parts += get_runnable_command(config.get(RUNTIME_CONFIG_KEY), target)

--- a/python/cloudtik/runtime/presto/utils.py
+++ b/python/cloudtik/runtime/presto/utils.py
@@ -79,7 +79,7 @@ def _is_runtime_scripts(script_file):
 
 
 def _get_runnable_command(target):
-    command_parts = ["presto", "-f", quote(target)]
+    command_parts = ["presto", "-f", target]
     return command_parts
 
 

--- a/python/cloudtik/runtime/spark/utils.py
+++ b/python/cloudtik/runtime/spark/utils.py
@@ -200,7 +200,7 @@ def _is_runtime_scripts(script_file):
 
 
 def _get_runnable_command(target):
-    command_parts = ["spark-shell", "-i", quote(target)]
+    command_parts = ["spark-shell", "-i", target]
     return command_parts
 
 

--- a/python/cloudtik/runtime/trino/utils.py
+++ b/python/cloudtik/runtime/trino/utils.py
@@ -74,7 +74,7 @@ def _is_runtime_scripts(script_file):
 
 
 def _get_runnable_command(target):
-    command_parts = ["trino", "-f", quote(target)]
+    command_parts = ["trino", "-f", target]
     return command_parts
 
 


### PR DESCRIPTION
### Description of the problem.

When submitting jobs to a cluster on host mode with the following commands:
```
cloudtik submit tpcds.yaml cloudtik/tools/benchmarks/spark/scripts/tpcds-power-test.scala --conf spark.driver.scaleFactor=1 --conf spark.driver.fsdir="gs://bucket"  --conf spark.driver.iterations=1  --jars '$HOME/runtime/benchmark-tools/spark-sql-perf/target/scala-2.12/spark-sql-perf_2.12-0.5.1-SNAPSHOT.jar'
```
We will encounter an issue as below.
```
Running `spark-shell -i '~/jobs/tpcds-power-test.scala' --conf spark.driver.scaleFactor=1 --conf spark.driver.fsdir=gs://bucket --conf spark.driver.iterations=1 --jars "$HOME/runtime/benchmark-tools/spark-sql-perf/target/scala-2.12/spark-sql-perf_2.12-0.5.1-SNAPSHOT.jar"`
  Full command is `…… bash --login -c -i 'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && (spark-shell -i '"'"'~/jobs/tpcds-power-test.scala'"'"' --conf spark.driver.scaleFactor=1 --conf spark.driver.fsdir=gs://bucket  --conf
….
Spark context available as 'sc' (master = yarn, app id = application_1661302518289_0001).
Spark session available as 'spark'.
warning: File `~/jobs/tpcds-power-test.scala' does not exist.

```


Also test a simple bash script 

```
$ cloudtik submit tpcds.yaml test.sh -v
Loaded cached provider configuration from /tmp/cloudtik-config-ac4fc2e6564b5fe86714dc640a12c8fa236a8657
If you experience issues with the cloud provider, try re-running the command with --no-config-cache.
Running `bash --login -c -i 'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && (mkdir -p ~/jobs)'`
  Full command is `kubectl -n kuworksp exec -it cloudtik-wh-head-8n4lq -- bash --login -c -i 'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && (mkdir -p ~/jobs)'`
sending incremental file list

sent 70 bytes  received 12 bytes  23.43 bytes/sec
total size is 19  speedup is 0.23
`rsync`ed test.sh (local) to ~/jobs/test.sh (remote)
Running `bash --login -c -i 'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && (bash '"'"'~/jobs/test.sh'"'"')'`
  Full command is `kubectl -n kuworksp exec -it cloudtik-wh-head-8n4lq -- bash --login -c -i 'true && source ~/.bashrc && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && (bash '"'"'~/jobs/test.sh'"'"')'`
bash: ~/jobs/test.sh: No such file or directory
command terminated with exit code 127
```

### The root cause

After the script file is uploaded to head node's directory `~/jobs/`,  it solves script path `~/jobs/<script_file>`.
There is a `~` in this string.  After calling quote, it becomes `'~/jobs/<script_file>'` . After additional calling quote, it will be `'"'"'~/jobs/<script_file>'"'"'`.
Then when running with `spark-shell -i` or `bash`  on head node, it will encounter the issue above.

### How does this PR fix the problem?

On docker and host modes:

For script arguments `script_args`, we keep using quote to be shell-escaped and no changes added.

For script path `~/jobs/<script_file>`, we can choose not to call quote.

