### PR TITLE
Process and save TPC-DS performance summary data for iterations

### DIFF
--- a/tools/benchmarks/spark/scripts/tpcds-power-test.scala
+++ b/tools/benchmarks/spark/scripts/tpcds-power-test.scala
@@ -134,7 +134,7 @@ import java.net.URI
 val fs = FileSystem.get(URI.create(finalResultPath), sc.hadoopConfiguration)
 val file = fs.globStatus(new Path(s"$finalResultPath/*.csv"))(0).getPath().getName()
 val srcPath=new Path(s"$finalResultPath/$file")
-val destPath= new Path(s"$finalResultPath/finalresult.csv")
+val destPath= new Path(s"$finalResultPath/summary.csv")
 fs.rename(srcPath, destPath)
 
 println(s"Performance summary is saved to ${destPath}")


### PR DESCRIPTION
Passed tests:
```
$ cloudtik submit small.yaml tpcds-power-test.scala --conf spark.driver.scaleFactor=1 --conf spark.driver.fsdir="gs://<bucket>"  --conf spark.driver.iterations=3   --jars '$HOME/runtime/benchmark-tools/spark-sql-perf/target/scala-2.12/spark-sql-perf_2.12-0.5.1-SNAPSHOT.jar'
......

Results written to table: 'sqlPerformance' at gs://<bucket>/shared/data/results/tpcds_parquet/1/timestamp=1663227200150
+--------+------+------+------+-----+----+-------+
|   Query|Round1|Round2|Round3|  Max| Min|Average|
+--------+------+------+------+-----+----+-------+
|q19-v2.4|  9.52|  4.05|  2.43| 9.52|2.43|   5.33|
|q20-v2.4|   4.2|  2.61|  2.29|  4.2|2.29|   3.03|
|   Total| 13.72|  6.66|  4.72|13.72|4.72|   8.36|
+--------+------+------+------+-----+----+-------+

Performance summary is saved to gs://<bucket>/shared/data/results/tpcds_parquet/1/timestamp=1663227200150/summary/finalresult.csv
```