### PR TITLE
Modify width of documentation web content

### DIFF
--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: none;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,3 +60,7 @@ from recommonmark.parser import CommonMarkParser
 
 source_suffix = {'.rst': 'restructuredtext',
                  '.md': 'markdown', }
+
+
+def setup(app):
+    app.add_css_file('style.css')


### PR DESCRIPTION
Modify width of documentation web content to adapt to the width of monitor window.  Here is the [demo](https://hongw2019-cloudtik.readthedocs.io/en/width/UserGuide/creating-cluster.html).