### PR TITLE
Enable Arm CI based on Travis CI

### DIFF
--- a/.traivs.yml
+++ b/.traivs.yml
@@ -1,0 +1,27 @@
+os: linux
+#dist: focal #ubuntu-20.04
+arch: arm64-graviton2
+virt: vm
+language: python
+compiler: gcc
+notifications:
+  email: false
+jobs:
+  include:
+    - name: build
+      if: branch = main
+      dist: trusty
+      script: bash ./build.sh
+    - name: unittests
+      dist: focal
+      python:
+        - 3.7
+        - 3.8
+        - 3.9
+      install:
+        - python -m pip install --upgrade pip
+        - pip install pytest
+        - if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      script:
+        - bash build.sh --no-build-ganglia
+        - pytest python/cloudtik/tests/unit


### PR DESCRIPTION
Try to enable CloudKit unittests and build github action jobs on Travis CI arm64-graviton2 platform.