### PR TITLE
Update HuaweiCloud provider default region and allocate EIP for head node

### DIFF
--- a/example/cluster/huaweicloud/example-obs.yaml
+++ b/example/cluster/huaweicloud/example-obs.yaml
@@ -10,7 +10,7 @@ workspace_name: example-workspace
 # Cloud-provider specific configuration.
 provider:
     type: huaweicloud
-    region: cn-east-2
+    region: ap-southeast-3
     use_managed_cloud_storage: False
     storage:
         # OBS configurations for storage

--- a/example/cluster/huaweicloud/example-standard.yaml
+++ b/example/cluster/huaweicloud/example-standard.yaml
@@ -10,10 +10,10 @@ workspace_name: example-workspace
 # Cloud-provider specific configuration.
 provider:
     type: huaweicloud
-    region: cn-east-2
+    region: ap-southeast-3
 
 auth:
-    ssh_user: ubuntu
+    ssh_user: root
     # Set proxy if you are in corporation network. For example,
     # ssh_proxy_command: "ncat --proxy-type socks5 --proxy your_proxy_host:your_proxy_port %h %p"
 

--- a/example/cluster/huaweicloud/example-workspace.yaml
+++ b/example/cluster/huaweicloud/example-workspace.yaml
@@ -4,7 +4,7 @@ workspace_name: example-workspace
 # Cloud-provider specific configuration.
 provider:
     type: huaweicloud
-    region: cn-east-2
+    region: ap-southeast-3
     # Use allowed_ssh_sources to allow SSH access from your client machine
     allowed_ssh_sources:
       - 0.0.0.0/0

--- a/python/cloudtik/core/_private/utils.py
+++ b/python/cloudtik/core/_private/utils.py
@@ -2855,3 +2855,13 @@ def get_command_session_name(cmd: str, timestamp: int):
     hasher.update(cmd.encode("utf-8"))
     hasher.update(timestamp_str.encode("utf-8"))
     return "cloudtik-" + hasher.hexdigest()
+
+
+def get_workspace_nat_public_ip_bandwidth_conf(
+        workspace_config: Dict[str, Any]) -> int:
+    return workspace_config.get('provider', {}).get('public_ip_bandwidth', 20)
+
+
+def get_cluster_node_public_ip_bandwidth_conf(
+        cluster_provider_config: Dict[str, Any]) -> int:
+    return cluster_provider_config.get('public_ip_bandwidth', 20)

--- a/python/cloudtik/core/config-schema.json
+++ b/python/cloudtik/core/config-schema.json
@@ -441,6 +441,11 @@
                     "type": "boolean",
                     "description": "Whether to assign worker with the role to access cloud storage.",
                     "default": true
+                },
+                "public_ip_bandwidth": {
+                    "type": "integer",
+                    "description": "Bandwidth of public ip in MB for node.",
+                    "default": 20
                 }
             }
         },

--- a/python/cloudtik/core/workspace-schema.json
+++ b/python/cloudtik/core/workspace-schema.json
@@ -202,6 +202,11 @@
                         "type": "string"
                     },
                     "description": "The list of CIDR definitions for hosts allowing ssh connection. For example, 0.0.0.0/0 for all hosts."
+                },
+                "public_ip_bandwidth": {
+                    "type": "integer",
+                    "description": "Bandwidth of public ip in MB for NAT.",
+                    "default": 20
                 }
             }
         }

--- a/python/cloudtik/providers/huaweicloud/defaults.yaml
+++ b/python/cloudtik/providers/huaweicloud/defaults.yaml
@@ -4,13 +4,13 @@ from: defaults
 # Cloud-provider specific configuration.
 provider:
     type: huaweicloud
-    region: cn-east-2
+    region: ap-southeast-3
     # Whether to use managed cloud storage of workspace.
     use_managed_cloud_storage: True
 
 # How we will authenticate with newly launched nodes.
 auth:
-    ssh_user: ubuntu
+    ssh_user: root
 # By default, we create a new private keypair, but you can also use your own.
 # If you do so, make sure to also set "KeyName" in the head and worker node
 # configurations below.
@@ -26,8 +26,8 @@ available_node_types:
         resources: {}
         # Provider-specific config for this node type, e.g. instance flavor.
         node_config:
-            image_ref: d4f60377-bb01-4a27-b119-c6de54fd4042
-            flavor_ref: ai1.xlarge.4
+            image_ref: 019b09ea-b960-46cd-abd8-306529e5eaa0
+            flavor_ref: ai1s.xlarge.4
             # key_name: key_pair_name
             root_volume:
                 volumetype: SSD
@@ -41,8 +41,8 @@ available_node_types:
         resources: {}
         # Provider-specific config for this node type, e.g. instance flavor.
         node_config:
-            image_ref: d4f60377-bb01-4a27-b119-c6de54fd4042
-            flavor_ref: ai1.xlarge.4
+            image_ref: 019b09ea-b960-46cd-abd8-306529e5eaa0
+            flavor_ref: ai1s.xlarge.4
             # key_name: key_pair_name
             root_volume:
                 volumetype: SSD

--- a/python/cloudtik/providers/huaweicloud/workspace-defaults.yaml
+++ b/python/cloudtik/providers/huaweicloud/workspace-defaults.yaml
@@ -4,7 +4,7 @@ from: workspace-defaults
 # Cloud-provider specific configuration.
 provider:
     type: huaweicloud
-    region: cn-east-2
+    region: ap-southeast-3
     # Decide whether to require public IP for head node.
     # When setting to False, Head node will require a public IP.
     # Default to False

--- a/python/cloudtik/runtime/common/conf/hadoop/huaweicloud/core-site.xml
+++ b/python/cloudtik/runtime/common/conf/hadoop/huaweicloud/core-site.xml
@@ -25,6 +25,10 @@
         <name>fs.obs.impl</name>
         <value>org.apache.hadoop.fs.obs.OBSFileSystem</value>
     </property>
+    <property>
+        <name>fs.obs.endpoint</name>
+        <value>{%fs.obs.endpoint.property%}</value>
+    </property>
     {%fs.obs.security.provider.property%}
     {%hadoop.credential.property%}
     <property>

--- a/python/cloudtik/runtime/spark/scripts/configure.sh
+++ b/python/cloudtik/runtime/spark/scripts/configure.sh
@@ -245,6 +245,7 @@ function update_config_for_aliyun() {
 function update_config_for_huaweicloud() {
     fs_default_dir="obs://${HUAWEICLOUD_OBS_BUCKET}"
     sed -i "s!{%fs.default.name%}!${fs_default_dir}!g" `grep "{%fs.default.name%}" -rl ./`
+    sed -i "s!{%fs.obs.endpoint.property%}!${HUAWEICLOUD_OBS_ENDPOINT}!g" `grep "{%fs.obs.endpoint.property%}" -rl ./`
 
     update_cloud_storage_credential_config
 

--- a/python/cloudtik/templates/huaweicloud/large.yaml
+++ b/python/cloudtik/templates/huaweicloud/large.yaml
@@ -6,7 +6,7 @@ provider:
 available_node_types:
     head.default:
         node_config:
-            flavor_ref: ai1.4xlarge.4
+            flavor_ref: ai1s.4xlarge.4
             root_volume:
                 volumetype: SSD
                 size: 100

--- a/python/cloudtik/templates/huaweicloud/medium.yaml
+++ b/python/cloudtik/templates/huaweicloud/medium.yaml
@@ -6,13 +6,13 @@ provider:
 available_node_types:
     head.default:
         node_config:
-            flavor_ref: ai1.4xlarge.4
+            flavor_ref: ai1s.4xlarge.4
             root_volume:
                 volumetype: SSD
                 size: 100
     worker.default:
         node_config:
-            flavor_ref: ai1.8xlarge.4
+            flavor_ref: ai1s.8xlarge.4
             root_volume:
                 volumetype: SSD
                 size: 100

--- a/python/cloudtik/templates/huaweicloud/small-highmem.yaml
+++ b/python/cloudtik/templates/huaweicloud/small-highmem.yaml
@@ -8,4 +8,4 @@ provider:
 available_node_types:
     worker.default:
         node_config:
-            flavor_ref: m6.xlarge.8
+            flavor_ref: ai1s.2xlarge.4

--- a/python/cloudtik/templates/huaweicloud/small.yaml
+++ b/python/cloudtik/templates/huaweicloud/small.yaml
@@ -6,13 +6,13 @@ provider:
 available_node_types:
     head.default:
         node_config:
-            flavor_ref: ai1.xlarge.4
+            flavor_ref: ai1s.xlarge.4
             root_volume:
                 volumetype: SSD
                 size: 100
     worker.default:
         node_config:
-            flavor_ref: ai1.xlarge.4
+            flavor_ref: ai1s.xlarge.4
             root_volume:
                 volumetype: ESSD
                 size: 200

--- a/python/cloudtik/templates/huaweicloud/standard-highmem.yaml
+++ b/python/cloudtik/templates/huaweicloud/standard-highmem.yaml
@@ -8,4 +8,4 @@ provider:
 available_node_types:
     worker.default:
         node_config:
-            flavor_ref: m6.2xlarge.8
+            flavor_ref: ai1s.4xlarge.4

--- a/python/cloudtik/templates/huaweicloud/standard.yaml
+++ b/python/cloudtik/templates/huaweicloud/standard.yaml
@@ -6,13 +6,13 @@ provider:
 available_node_types:
     head.default:
         node_config:
-            flavor_ref: ai1.2xlarge.4
+            flavor_ref: ai1s.2xlarge.4
             root_volume:
                 volumetype: SSD
                 size: 100
     worker.default:
         node_config:
-            flavor_ref: ai1.2xlarge.4
+            flavor_ref: ai1s.2xlarge.4
             root_volume:
                 volumetype: SSD
                 size: 100

--- a/python/cloudtik/templates/huaweicloud/very-large.yaml
+++ b/python/cloudtik/templates/huaweicloud/very-large.yaml
@@ -6,7 +6,7 @@ provider:
 available_node_types:
     head.default:
         node_config:
-            flavor_ref: ai1.4xlarge.4
+            flavor_ref: ai1s.4xlarge.4
             root_volume:
                 volumetype: SSD
                 size: 100


### PR DESCRIPTION
1. "ap-southeast-3" region is in Singapore, we can use more stable
and speed networking access to some resources.
2. Update server flavor and image to match the region.
3. Allocate and attach EIP to head node
4. Add workspace security group egress rule
5. Add workspace subnet DNS option
6. Add configurable workspace bandwidth option for EIP and NAT

Related-with: #1011
