### PR TITLE
Get HuaweiCloud provider default cluster image

### DIFF
--- a/python/cloudtik/providers/_private/huaweicloud/utils.py
+++ b/python/cloudtik/providers/_private/huaweicloud/utils.py
@@ -12,6 +12,8 @@ from huaweicloudsdkeip.v2 import EipClient
 from huaweicloudsdkeip.v2.region.eip_region import EipRegion
 from huaweicloudsdkiam.v3 import IamClient
 from huaweicloudsdkiam.v3.region.iam_region import IamRegion
+from huaweicloudsdkims.v2 import ImsClient
+from huaweicloudsdkims.v2.region.ims_region import ImsRegion
 from huaweicloudsdknat.v2 import NatClient
 from huaweicloudsdknat.v2.region.nat_region import NatRegion
 from huaweicloudsdkvpc.v2 import VpcClient
@@ -19,7 +21,7 @@ from huaweicloudsdkvpc.v2.region.vpc_region import VpcRegion
 from obs import ObsClient
 
 from cloudtik.core._private.constants import \
-    CLOUDTIK_DEFAULT_CLOUD_STORAGE_URI, env_bool, env_integer
+    CLOUDTIK_DEFAULT_CLOUD_STORAGE_URI, env_bool
 from cloudtik.core._private.utils import get_storage_config_for_update
 
 OBS_SERVICES_URL = 'https://obs.{location}.myhuaweicloud.com'
@@ -81,6 +83,13 @@ def _client_cache(region: str = None, ak: str = None, sk: str = None) -> Dict[
         .with_region(IamRegion.value_of(region) if region else None) \
         .build()
     client_map['iam'] = iam_client
+
+    ims_client = ImsClient.new_builder() \
+        .with_http_config(http_config) \
+        .with_credentials(credentials) \
+        .with_region(ImsRegion.value_of(region) if region else None) \
+        .build()
+    client_map['ims'] = ims_client
 
     ignore_ssl_verification = env_bool('HWC_IGNORE_SSL_VERIFICATION', False)
     if ignore_ssl_verification:
@@ -161,6 +170,14 @@ def make_iam_client(config: Dict[str, Any], region=None) -> Any:
 
 def _make_iam_client(config_provider: Dict[str, Any], region=None) -> Any:
     return _make_client(config_provider, 'iam', region)
+
+
+def make_ims_client(config: Dict[str, Any], region=None) -> Any:
+    return _make_ims_client(config['provider'], region)
+
+
+def _make_ims_client(config_provider: Dict[str, Any], region=None) -> Any:
+    return _make_client(config_provider, 'ims', region)
 
 
 def make_obs_client_aksk(ak: str, sk: str, region: str = None) -> Any:

--- a/python/cloudtik/providers/huaweicloud/defaults.yaml
+++ b/python/cloudtik/providers/huaweicloud/defaults.yaml
@@ -26,8 +26,8 @@ available_node_types:
         resources: {}
         # Provider-specific config for this node type, e.g. instance flavor.
         node_config:
-            image_ref: 019b09ea-b960-46cd-abd8-306529e5eaa0
             flavor_ref: ai1s.xlarge.4
+            # image_ref: 019b09ea-b960-46cd-abd8-306529e5eaa0
             # key_name: key_pair_name
             root_volume:
                 volumetype: SSD
@@ -41,8 +41,8 @@ available_node_types:
         resources: {}
         # Provider-specific config for this node type, e.g. instance flavor.
         node_config:
-            image_ref: 019b09ea-b960-46cd-abd8-306529e5eaa0
             flavor_ref: ai1s.xlarge.4
+            # image_ref: 019b09ea-b960-46cd-abd8-306529e5eaa0
             # key_name: key_pair_name
             root_volume:
                 volumetype: SSD

--- a/python/setup.py
+++ b/python/setup.py
@@ -97,11 +97,12 @@ setup_spec.extras = {
         "kopf",
     ],
     "huaweicloud": [
-        "huaweicloudsdkecs == 3.1.24",
-        "huaweicloudsdkvpc == 3.1.24",
-        "huaweicloudsdknat == 3.1.24",
-        "huaweicloudsdkeip == 3.1.24",
-        "huaweicloudsdkiam == 3.1.24",
+        "huaweicloudsdkecs == 3.1.35",
+        "huaweicloudsdkvpc == 3.1.35",
+        "huaweicloudsdknat == 3.1.35",
+        "huaweicloudsdkeip == 3.1.35",
+        "huaweicloudsdkiam == 3.1.35",
+        "huaweicloudsdkims == 3.1.35",
         "esdk-obs-python == 3.22.2",
     ],
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,9 +49,10 @@ alibabacloud_ecs20140526 == 3.0.4
 alibabacloud_ram20150501 == 1.0.3
 alibabacloud_oss20190517 == 1.0.5
 ## for huaweicloud
-huaweicloudsdkecs == 3.1.24
-huaweicloudsdkvpc == 3.1.24
-huaweicloudsdknat == 3.1.24
-huaweicloudsdkeip == 3.1.24
-huaweicloudsdkiam == 3.1.24
+huaweicloudsdkecs == 3.1.35
+huaweicloudsdkvpc == 3.1.35
+huaweicloudsdknat == 3.1.35
+huaweicloudsdkeip == 3.1.35
+huaweicloudsdkiam == 3.1.35
+huaweicloudsdkims == 3.1.35
 esdk-obs-python == 3.22.2


### PR DESCRIPTION
1. Remove the image_ref UUID in defaults.yaml in HuaweiCloud provider, try to get default image if user don't specify image_ref
2. Update HuaweiCloud Python SDK versions

Related-with: #1011