### PR TITLE
Revert "AI: fix mpi args parameter name and standardize the names"

### DIFF
--- a/python/cloudtik/runtime/ai/runner/__init__.py
+++ b/python/cloudtik/runtime/ai/runner/__init__.py
@@ -6,14 +6,14 @@ class _LaunchArgs(object):
         self.executable = None
 
         # nodes and processes
-        # If num_nodes and num_proc_per_node is specified
+        # If nnodes and nproc_per_node is specified
         # hosts/hostfile can be host address only without slots
         # Or you can specify hosts with slots and specify the num_proc
         # all these are handled by Distributor
 
         self.num_proc = None
-        self.num_nodes = None
-        self.num_proc_per_node = None
+        self.nnodes = None
+        self.nproc_per_node = None
 
         # host arguments
         self.hosts = None
@@ -37,7 +37,7 @@ class _LaunchArgs(object):
 
         # library arguments
         # MPI
-        self.mpi_args = None
+        self.more_mpi_args = None
         self.tcp_flag = None
         self.binding_args = None
         self.num_nccl_streams = None
@@ -61,8 +61,8 @@ def run(
         args=(),
         kwargs=None,
         num_proc=None,
-        num_nodes=None,
-        num_proc_per_node=None,
+        nnodes=None,
+        nproc_per_node=None,
         hosts=None,
         hostfile=None,
         output_filename=None,
@@ -82,8 +82,8 @@ def run(
     :param args: Arguments to pass to `func`.
     :param kwargs: Keyword arguments to pass to `func`.
     :param num_proc: The number of processes for running.
-    :param num_nodes: The number of nodes. if not specified, use the number of nodes in the hosts
-    :param num_proc_per_node: The number of process per node.
+    :param nnodes: The number of nodes. if not specified, use the number of nodes in the hosts
+    :param nproc_per_node: The number of process per node.
     :param hosts: List of host names and the number of available slots
                   for running processes on each, of the form: <hostname>:<slots>
                   (e.g.: host1:2,host2:4,host3:1 indicating 2 processes can run on host1,
@@ -124,12 +124,12 @@ def run(
     largs = _LaunchArgs()
 
     largs.num_proc = num_proc
-    largs.num_nodes = num_nodes
-    largs.num_proc_per_node = num_proc_per_node
+    largs.nnodes = nnodes
+    largs.nproc_per_node = nproc_per_node
     largs.hosts = hosts
     largs.hostfile = hostfile
     largs.launcher = "horovod"
-    largs.mpi_args = mpi_args
+    largs.more_mpi_args = mpi_args
     largs.output_filename = output_filename
     largs.verbose = verbose
     largs.use_gloo = use_gloo
@@ -145,8 +145,8 @@ def run_command(
         program,
         program_args=None,
         num_proc=None,
-        num_nodes=None,
-        num_proc_per_node=None,
+        nnodes=None,
+        nproc_per_node=None,
         hosts=None,
         hostfile=None,
         launcher=None,
@@ -163,8 +163,8 @@ def run_command(
     :param program: The program to be run in job processes.
     :param program_args: The list of program arguments
     :param num_proc: The number of processes for running.
-    :param num_nodes: The number of nodes. if not specified, use the number of nodes in the hosts
-    :param num_proc_per_node: The number of process per node.
+    :param nnodes: The number of nodes. if not specified, use the number of nodes in the hosts
+    :param nproc_per_node: The number of process per node.
     :param hosts: List of host names and the number of available slots
                   for running processes on each, of the form: <hostname>:<slots>
                   (e.g.: host1:2,host2:4,host3:1 indicating 2 processes can run on host1,
@@ -197,12 +197,12 @@ def run_command(
     largs = _LaunchArgs()
 
     largs.num_proc = num_proc
-    largs.num_nodes = num_nodes
-    largs.num_proc_per_node = num_proc_per_node
+    largs.nnodes = nnodes
+    largs.nproc_per_node = nproc_per_node
     largs.hosts = hosts
     largs.hostfile = hostfile
     largs.launcher = launcher
-    largs.mpi_args = mpi_args
+    largs.more_mpi_args = mpi_args
     largs.output_filename = output_filename
     largs.verbose = verbose
     largs.use_gloo = use_gloo

--- a/python/cloudtik/runtime/ai/runner/cpu/default_training_launcher.py
+++ b/python/cloudtik/runtime/ai/runner/cpu/default_training_launcher.py
@@ -106,11 +106,11 @@ class DefaultTrainingLauncher(CPULauncher, DistributedTrainingLauncher):
         self.distributor.validate_same_slots()
 
         num_proc = self.distributor.num_proc
-        num_proc_per_node = self.distributor.num_proc_per_node
+        nproc_per_node = self.distributor.nproc_per_node
 
         cmd = ['mpirun']
         mpi_config = "-l -np {} -ppn {} ".format(
-            num_proc, num_proc_per_node)
+            num_proc, nproc_per_node)
         mpi_config += args.mpi_args
 
         if self.distributor.distributed:

--- a/python/cloudtik/runtime/ai/runner/cpu/optimized_training_launcher.py
+++ b/python/cloudtik/runtime/ai/runner/cpu/optimized_training_launcher.py
@@ -13,7 +13,7 @@ class OptimizedTrainingLauncher(DefaultTrainingLauncher):
     def __init__(self, args, distributor):
         super().__init__(args, distributor)
 
-    def get_mpi_pin_domain(self, num_proc_per_node, ccl_worker_count, total_cores, flatten_node_cores):
+    def get_mpi_pin_domain(self, nproc_per_node, ccl_worker_count, total_cores, flatten_node_cores):
         '''
         I_MPI_PIN_DOMAIN specify the cores used for every MPI process.
         The first ccl_worker_count cores of every rank for ccl communication
@@ -23,7 +23,7 @@ class OptimizedTrainingLauncher(DefaultTrainingLauncher):
         CCL_WORKER_AFFINITY="0,1,2,3,28,29,30,31"
         I_MPI_PIN_DOMAIN=[0xffffff0,0xffffff0000000]
         '''
-        ppn = num_proc_per_node
+        ppn = nproc_per_node
         cores_per_rank = total_cores // ppn
 
         pin_domain = "["
@@ -40,13 +40,13 @@ class OptimizedTrainingLauncher(DefaultTrainingLauncher):
         pin_domain += "]"
         return pin_domain
 
-    def get_ccl_worker_affinity(self, num_proc_per_node, ccl_worker_count, total_cores, flatten_node_cores):
+    def get_ccl_worker_affinity(self, nproc_per_node, ccl_worker_count, total_cores, flatten_node_cores):
         '''
         Computation and communication use different cores when using oneCCL
         backend for distributed training. we use first ccl_worker_count cores of
         every rank for ccl communication
         '''
-        ppn = num_proc_per_node
+        ppn = nproc_per_node
         cores_per_rank = total_cores // ppn
         affinity = ''
         for proc in range(ppn):
@@ -75,17 +75,17 @@ class OptimizedTrainingLauncher(DefaultTrainingLauncher):
 
         self.distributor.resolve(cpuinfo.sockets())
 
-        num_proc_per_node = self.distributor.num_proc_per_node
+        nproc_per_node = self.distributor.nproc_per_node
 
         flatten_node_cores = []
         for node_numa_cores in node_cores:
             flatten_node_cores.extend(node_numa_cores)
 
         mpi_pin_domain = self.get_mpi_pin_domain(
-            num_proc_per_node, args.ccl_worker_count, total_cores_per_node, flatten_node_cores)
+            nproc_per_node, args.ccl_worker_count, total_cores_per_node, flatten_node_cores)
         self.set_env("I_MPI_PIN_DOMAIN", mpi_pin_domain)
 
-        ppn = num_proc_per_node
+        ppn = nproc_per_node
         cores_per_rank = total_cores_per_node // ppn
 
         omp_num_threads = cores_per_rank - args.ccl_worker_count
@@ -98,5 +98,5 @@ class OptimizedTrainingLauncher(DefaultTrainingLauncher):
 
         self.set_env("CCL_WORKER_COUNT", str(args.ccl_worker_count))
         ccl_affinity = self.get_ccl_worker_affinity(
-            num_proc_per_node, args.ccl_worker_count, total_cores_per_node, flatten_node_cores)
+            nproc_per_node, args.ccl_worker_count, total_cores_per_node, flatten_node_cores)
         self.set_env("CCL_WORKER_AFFINITY", ccl_affinity)

--- a/python/cloudtik/runtime/ai/runner/launch.py
+++ b/python/cloudtik/runtime/ai/runner/launch.py
@@ -95,8 +95,8 @@ rank 0: *(IP: 192.168.10.10, and has a free port: 295000)*
 
 ::
 
-    >>> cloudtik-ai-run --distributed --num-proc-per-node=xxx
-               --num-nodes=2 --hostfile hostfile python_sript --arg1 --arg2 --arg3
+    >>> cloudtik-ai-run --distributed --nproc_per_node=xxx
+               --nnodes=2 --hostfile hostfile python_sript --arg1 --arg2 --arg3
                and all other arguments of your training script)
 
 
@@ -121,14 +121,13 @@ def add_cpu_option_params(parser):
 
 def add_distributed_training_params(parser):
     group = parser.add_argument_group("Distributed Training Parameters")
-    group.add_argument('--num-proc', action='store', dest='num_proc',
+    group.add_argument('-np', '--num-proc', action='store', dest='num_proc',
                        metavar='\b', type=int, default=0,
                        help="The number of process to run for distributed training")
-    group.add_argument("--num-nodes", "--nnodes", action='store', dest='num_nodes',
-                       metavar='\b', type=int, default=0,
+    group.add_argument("--nnodes", metavar='\b', type=int, default=0,
                        help="The number of nodes to use for distributed "
                        "training")
-    group.add_argument("--num-proc-per-node", "--nproc_per_node", action='store', dest='num_proc_per_node',
+    group.add_argument("--nproc-per-node", "--nproc_per_node", action='store', dest='nproc_per_node',
                        metavar='\b', type=int, default=0,
                        help="The number of processes to launch on each node")
     group.add_argument("--hosts", metavar='\b', default="", type=str,
@@ -256,8 +255,8 @@ def parse_args():
                     "\n    >>> cloudtik-ai-run --distributed  python_script args\n"
                     "\n4. Multi-Node multi-process distributed training: (e.g. two nodes)\n"
                     "\n   rank 0: *(IP: 192.168.10.10, and has a free port: 295000)*\n"
-                    "\n   >>> cloudtik-ai-run --distributed --num-proc-per-node=2\n"
-                    "\n       --num-nodes=2 --hostfile hostfile python_script args\n"
+                    "\n   >>> cloudtik-ai-run --distributed --nproc_per_node=2\n"
+                    "\n       --nnodes=2 --hostfile hostfile python_script args\n"
                     "\n############################################################################# \n",
                     formatter_class=RawTextHelpFormatter)
 
@@ -351,8 +350,8 @@ def _setup_logger(args):
 def _run(args):
     distributor = Distributor(
         args.num_proc,
-        args.num_nodes,
-        args.num_proc_per_node,
+        args.nnodes,
+        args.nproc_per_node,
         args.hosts,
         args.hostfile,
     )

--- a/python/cloudtik/tests/unit/runtime/test_ai_utils.py
+++ b/python/cloudtik/tests/unit/runtime/test_ai_utils.py
@@ -6,14 +6,14 @@ from cloudtik.runtime.ai.runner.util.distributor import Distributor
 class TestAIUtils:
     def test_distributor(self):
         distributor = Distributor(
-            num_nodes=2,
-            num_proc_per_node=2,
+            nnodes=2,
+            nproc_per_node=2,
             hosts="10.0.0.1, 10.0.0.2"
         )
 
         assert distributor.num_proc == 4
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 2
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 2
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 2
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
@@ -24,8 +24,8 @@ class TestAIUtils:
             hosts="10.0.0.1, 10.0.0.2"
         )
         assert distributor.num_proc == 4
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 2
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 2
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 2
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
@@ -36,8 +36,8 @@ class TestAIUtils:
         )
 
         assert distributor.num_proc == 4
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 2
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 2
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 2
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
@@ -48,8 +48,8 @@ class TestAIUtils:
         )
 
         assert distributor.num_proc == 6
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 3
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 3
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 2
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
@@ -57,24 +57,24 @@ class TestAIUtils:
 
         distributor = Distributor(
             num_proc=6,
-            num_proc_per_node=2,
+            nproc_per_node=2,
             hosts="10.0.0.1:6, 10.0.0.2"
         )
         assert distributor.num_proc == 6
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 3
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 3
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 6
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
         assert distributor.hosts[1]["slots"] == 2
 
         distributor = Distributor(
-            num_proc_per_node=2,
+            nproc_per_node=2,
             hosts="10.0.0.1, 10.0.0.2"
         )
         assert distributor.num_proc == 4
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 2
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 2
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 2
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
@@ -85,24 +85,24 @@ class TestAIUtils:
             hosts="10.0.0.1:3, 10.0.0.2:3"
         )
         assert distributor.num_proc == 4
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 2
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 2
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 3
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
         assert distributor.hosts[1]["slots"] == 3
 
-        # for this case, we default num_proc_per_node == sockets_per_node
+        # for this case, we default nproc_per_node == sockets_per_node
         distributor = Distributor(
             hosts="10.0.0.1, 10.0.0.2"
         )
         assert not distributor.resolved
-        assert distributor.num_nodes == 2
+        assert distributor.nnodes == 2
 
         distributor.resolve(3)
         assert distributor.num_proc == 6
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 3
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 3
         assert distributor.hosts[0]["ip"] == "10.0.0.1"
         assert distributor.hosts[0]["slots"] == 3
         assert distributor.hosts[1]["ip"] == "10.0.0.2"
@@ -112,15 +112,15 @@ class TestAIUtils:
 
         distributor.resolve(4)
         assert distributor.num_proc == 6
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 3
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 3
         assert distributor.hosts[0]["slots"] == 3
         assert distributor.hosts[1]["slots"] == 3
 
         distributor.resolve(4, force=True)
         assert distributor.num_proc == 8
-        assert distributor.num_nodes == 2
-        assert distributor.num_proc_per_node == 4
+        assert distributor.nnodes == 2
+        assert distributor.nproc_per_node == 4
         assert distributor.hosts[0]["slots"] == 4
         assert distributor.hosts[1]["slots"] == 4
 


### PR DESCRIPTION
This reverts commit 3820835aba2c46fcc64e005d4b33a47d1d76c639.