### PR TITLE
Return empty dict of _get_existing_port_mapping funtion when there is no existing port mapping to avoid uniterable value error

### DIFF
--- a/python/cloudtik/providers/_private/virtual/config.py
+++ b/python/cloudtik/providers/_private/virtual/config.py
@@ -180,7 +180,7 @@ def _get_existing_port_mapping():
         cmd
     ).decode().strip()
     if not output:
-        return 0
+        return {}
     existing_port_mappings = {}
     lines = output.splitlines()
     for line in lines:


### PR DESCRIPTION
… no existing port mapping, so that we can avoid the error that 'int' is not iterable